### PR TITLE
Unlist python 2 dependencies

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -7,8 +7,6 @@
     update_cache: yes
     pkg:
       - build-essential
-      - python-dev
-      - python-setuptools
       - python3-dev
       - python3-setuptools
       - libxml2


### PR DESCRIPTION
According to @danypr92 , we don't use python2 anymore and it's worth it to check, so that we can avoid unnecessary dependencies.

Tested by doing:
1. Removing `.venv` dir in the odoo filesystem → force to install again the dependencies.
2. Applying this commit locally → so that ansible does not use them.
3. Running provision.yml of odoo-provisioning with dev and local variables.

As all packages could be installed (setuptools is needed in this process for some of them) and odoo is running again